### PR TITLE
Create Setup.hs for build without cabal-install wrapper

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,0 +1,4 @@
+#! /usr/bin/env runhaskell
+
+import Distribution.Simple
+main = defaultMain


### PR DESCRIPTION
All rpm based distributions using directly Cabal and Setup.hs file:

whithout this build faild